### PR TITLE
Bump to dablin 1.1.0

### DIFF
--- a/dablin-fdk-aac.patch
+++ b/dablin-fdk-aac.patch
@@ -1,9 +1,0 @@
---- Makefile.orig	2016-08-21 21:55:16.156884885 +0200
-+++ Makefile	2016-08-21 21:56:29.308825415 +0200
-@@ -1,5 +1,5 @@
- # uncomment the following line to use FDK-AAC instead of FAAD2 for audio decoding:
--#use_fdk-aac = true
-+use_fdk-aac = true
- 
- # uncomment the following line to disable SDL output:
- #disable_sdl = true

--- a/dablin.spec
+++ b/dablin.spec
@@ -33,7 +33,7 @@ Source0:  https://github.com/Opendigitalradio/dablin/archive/%{version}.tar.gz#/
 
 BuildRequires: gcc-c++
 BuildRequires: libfec-odr-devel
-BuildRequires: fdk-aac-dabplus-odr-devel
+BuildRequires: faad2-devel
 BuildRequires: libmpg123-devel
 BuildRequires: SDL2-devel
 BuildRequires: gtkmm30-devel
@@ -57,7 +57,7 @@ from a stored ensemble recording (frame-aligned ETI-NI). Both DAB (MP2) and DAB+
 %setup -q
 
 %build
-make USE_FDK-AAC=1
+make
 
 %install
 install -d %{buildroot}/usr/bin/
@@ -75,6 +75,7 @@ install dablin_gtk %{buildroot}/usr/bin/
 %changelog
 * Wed Oct 22 2016 Lucas Bickel <hairmare@purplehaze.ch> - 1.1.0-1
 - Bump to upstream version 1.1.0
+- Use faad2 aac decoder instead of fdk-aac-dabplus-odr
 
 * Wed Sep 28 2016 Lucas Bickel <hairmare@purplehaze.ch> - 1.0.0-2
 - Adapted to accommodate changes to upstream fdk-aac-dabplus-odr package

--- a/dablin.spec
+++ b/dablin.spec
@@ -24,13 +24,12 @@
 
 Name:     dablin
 
-Version:  1.0.0
-Release:  2%{?dist}
+Version:  1.1.0
+Release:  1%{?dist}
 Summary:  DAB/DAB+ receiver for Linux (including ETI-NI playback)
 License:  GPLv3+
 URL:      https://github.com/Opendigitalradio/dablin
 Source0:  https://github.com/Opendigitalradio/dablin/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
-Patch0:   dablin-fdk-aac.patch
 
 BuildRequires: gcc-c++
 BuildRequires: libfec-odr-devel
@@ -57,11 +56,8 @@ from a stored ensemble recording (frame-aligned ETI-NI). Both DAB (MP2) and DAB+
 %prep
 %setup -q
 
-# Use Opendigitalradio's modified version of fdk-aac (fdk-aac-dabplus)
-%patch0
-
 %build
-make
+make USE_FDK-AAC=1
 
 %install
 install -d %{buildroot}/usr/bin/
@@ -77,6 +73,9 @@ install dablin_gtk %{buildroot}/usr/bin/
 
 
 %changelog
+* Wed Oct 22 2016 Lucas Bickel <hairmare@purplehaze.ch> - 1.1.0-1
+- Bump to upstream version 1.1.0
+
 * Wed Sep 28 2016 Lucas Bickel <hairmare@purplehaze.ch> - 1.0.0-2
 - Adapted to accommodate changes to upstream fdk-aac-dabplus-odr package
 


### PR DESCRIPTION
The new version that was recently published at https://github.com/Opendigitalradio/dablin/releases/tag/1.1.0 should bring mot_encoder support to dablin.
