### PR TITLE
Version Bump - 1.6.0

### DIFF
--- a/dablin.spec
+++ b/dablin.spec
@@ -24,7 +24,7 @@
 
 Name:     dablin
 
-Version:  1.5.0
+Version:  1.6.0
 Release:  1%{?dist}
 Summary:  DAB/DAB+ receiver for Linux (including ETI-NI playback)
 # The entire source code is GPLv3+ except fec/ which is LGPLv2.1+
@@ -75,6 +75,9 @@ make install DESTDIR=%{buildroot}
 
 
 %changelog
+* Mon Oct 02 2017 Christian Affolter <c.affolter@purplehaze.ch> - 1.6.0-1
+- Bump to upstream version 1.6.0
+
 * Sun Jun 11 2017 Christian Affolter <c.affolter@purplehaze.ch> - 1.5.0-1
 - Bump to upstream version 1.5.0
 

--- a/dablin.spec
+++ b/dablin.spec
@@ -41,18 +41,18 @@ BuildRequires: SDL2-devel
 BuildRequires: gtkmm30-devel
 
 %description
-DABlin plays a DAB/DAB+ audio service - either from a received live transmission or
-from a stored ensemble recording (frame-aligned ETI-NI). Both DAB (MP2) and DAB+ 
-(AAC-LC, HE-AAC, HE-AAC v2) services are supported.
+DABlin plays a DAB/DAB+ audio service - either from a received live
+transmission or from a stored ensemble recording (frame-aligned ETI-NI). Both
+DAB (MP2) and DAB+ (AAC-LC, HE-AAC, HE-AAC v2) services are supported.
 
 %package -n dablin-gtk
 Summary:  DAB/DAB+ receiver for Linux/GTK (including ETI-NI playback)
 Requires: %{name} = %{version}-%{release}
 
 %description -n dablin-gtk
-DABlin plays a DAB/DAB+ audio service - either from a received live transmission or
-from a stored ensemble recording (frame-aligned ETI-NI). Both DAB (MP2) and DAB+ 
-(AAC-LC, HE-AAC, HE-AAC v2) services are supported.
+DABlin plays a DAB/DAB+ audio service - either from a received live
+transmission or from a stored ensemble recording (frame-aligned ETI-NI). Both
+DAB (MP2) and DAB+ (AAC-LC, HE-AAC, HE-AAC v2) services are supported.
 
 
 %prep


### PR DESCRIPTION
Version bump according to new [Dablin 1.6.0 release](https://github.com/Opendigitalradio/dablin/releases/tag/1.6.0).